### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Introduction
 .. image:: https://secure.travis-ci.org/Haufe-Lexware/hl.pas.samlplugin.png
     :target: http://travis-ci.org/Haufe-Lexware/hl.pas.samlplugin
 
-.. image:: https://pypip.in/v/hl.pas.samlplugin/badge.png
+.. image:: https://img.shields.io/pypi/v/hl.pas.samlplugin.svg
     :target: https://pypi.python.org/pypi/hl.pas.samlplugin/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hl-pas-samlplugin))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hl-pas-samlplugin`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.